### PR TITLE
Add warning about project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# THIS REPOSITORY IS A PLACEHOLDER 
+
+This repository is a placeholder for future work and is not a functional bridge between CloudFoundry metric output and CloudWatch metric input.
+
+Your best bet at present to bridge the two is via statsd and its cloudwatch plugin. If you know better, please edit this README.
+
+The README from the datadog-firehose-nozzle now follows:
+
+======
+
 ## Summary
 [![Build Status](https://travis-ci.org/cloudfoundry-incubator/datadog-firehose-nozzle.svg?branch=master)](https://travis-ci.org/cloudfoundry-incubator/datadog-firehose-nozzle) [![Coverage Status](https://coveralls.io/repos/cloudfoundry-incubator/datadog-firehose-nozzle/badge.svg)](https://coveralls.io/r/cloudfoundry-incubator/datadog-firehose-nozzle)
 


### PR DESCRIPTION
Unless I'm missing something massive, this project does not yet do what it suggests in its name.

Am I right in saying that it has been unchanged since the fork from the datadog connector, several years ago? Maybe it should be deleted to avoid confusion?

If not, this warning will hopefully save some time for other people who stumble here looking for a connector from CloudFoundry metrics output to CloudWatch metrics input.

(If anyone knows of a good way to connect those two things, I am currently looking and would be grateful for any suggestions.)